### PR TITLE
Extend LW maximum_party_size

### DIFF
--- a/Halo 3/Release/default_hoppers/hoppers/00108/configuration.json
+++ b/Halo 3/Release/default_hoppers/hoppers/00108/configuration.json
@@ -27,7 +27,7 @@
     "minimum_games_played": 0,
     "maximum_games_played": 0,
     "minimum_party_size": 1,
-    "maximum_party_size": 1,
+    "maximum_party_size": 4,
     "hopper_access_bit": -1,
     "account_type_access": 0,
     "require_all_party_members_meet_games_played_requirements": false,


### PR DESCRIPTION
Lone Wolves maximum_party_size upped from 1 to 4 to allow easier ranked matching